### PR TITLE
Clearing the `keysPressed` slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,7 @@ pass additional information about the pressed keys:
   - `TAB` was pressed - User moved to the next input field on a website
   - `Up`, `Down`, `Left` and `Right` keys were pressed - User looked at the screen and moved his cross-hair
   - `Delete` or `Back Space` keys were pressed - User deleted text, he wants to fix the error himself
-  - `CAPS-LOCK` was pressed - Logic like `SHIFT` needs to be implemented
   - Timeout - The user left the keyboard for a long time (make it configurable)
-  - Slice limit reached - The user can configure how many letter will be stored in the `keysPressed` slice to keep the 
-memory from overloading
 
 ## Fixes 🌌
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -6,18 +6,21 @@ import (
 	"keyboard/keylogger"
 	"keyboard/objects"
 	"keyboard/typer"
+	"time"
 )
 
 var (
 	keysPressed       []objects.Letter
 	pressedKeysChan   = make(chan objects.Letter) // Channel for all pressed keys
 	stopKeyloggerChan = make(chan bool)           // Telling the keylogger.KeyLogger() method to stop key-logging
+	resetTimerChan    = make(chan bool)           // Flushing the pressedKeysChan slice nothing is pressed for a while
 )
 
 // Start key-logs the users keyboard. When the help flag is raised it removes the wrong typed keys replacing them
 // with the correct ones.
 func Start(keyboard keybd_event.KeyBonding) {
 	go keylogger.KeyLogger(pressedKeysChan, stopKeyloggerChan) // Start key-logging the keyboard
+	flushSliceTimer(resetTimerChan)
 
 	for key := range pressedKeysChan {
 		switch key.KeyboardEvent.ScanCode {
@@ -34,7 +37,27 @@ func Start(keyboard keybd_event.KeyBonding) {
 			keysPressed = keysPressed[:0]
 
 		default:
+			resetTimerChan <- true
 			keysPressed = append(keysPressed, key)
 		}
 	}
+}
+
+// flushSliceTimer creates a timer, it waits for 5 seconds after the last key was pressed. When the time runs out
+// the method flushed the keysPressed slice.
+func flushSliceTimer(resetChan chan bool) {
+	timer := time.NewTimer(5 * time.Second) // Initial timer set to 5 seconds
+
+	go func() {
+		for {
+			select {
+			case <-timer.C:
+				fmt.Println("controller: Times out - Flushing the keysPressed slice.")
+				keysPressed = keysPressed[:0]
+				timer.Reset(5 * time.Second) // Reset the timer
+			case <-resetChan:
+				timer.Reset(5 * time.Second) // Reset the timer when the condition is met
+			}
+		}
+	}()
 }


### PR DESCRIPTION
- [#9](https://github.com/zigelboim-misha/go-retyper/pull/9) - Clearing the `keysPressed` slice when:
  - `TAB` was pressed - User moved to the next input field on a website
  - `Up`, `Down`, `Left` and `Right` keys were pressed - User looked at the screen and moved his cross-hair
  - `Delete` or `Back Space` keys were pressed - User deleted text, he wants to fix the error himself
  - `CAPS-LOCK` was pressed - Logic like `SHIFT` needs to be implemented
  - Timeout - The user left the keyboard for a long time (make it configurable)
  - Slice limit reached - The user can configure how many letter will be stored in the `keysPressed` slice to keep the 
memory from overloading